### PR TITLE
Added Non-Standard URI (Sandbox) Support

### DIFF
--- a/lib/landslider.rb
+++ b/lib/landslider.rb
@@ -1,4 +1,3 @@
-
 require 'handsoap'
 
 # landslider gem main class
@@ -7,7 +6,7 @@ class Landslider < Handsoap::Service
 	require 'landslider/entities'
 
 	LS_API_NAMESPACE='http://www.landslide.com/webservices/SoapService'
-	LS_API_ENDPOINT = {
+	LS_API_ENDPOINT ||= {
 	  :uri => "https://#{LS_INSTANCE_NAME}.api.landslide.com/webservices/SoapService",
 	  :version => 1
 	}


### PR DESCRIPTION
Modified LS_API_ENDPOINT to use predefined constant (from boot.rb or elsewhere) if it is already defined. This allows for use of non-standard URIs (i.e. Sandboxes), custom ports, etc.
